### PR TITLE
fix(history): ignore adding empty commands to bash and zsh history

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,27 @@
 1. copy the following command to your terminal:
 
 ```bash
-# find-alias
 function find-alias {
-if [[ -n "$BASH" ]]; then
-history -s find-alias "$@"
-fi
+  if [[ -n "$BASH" ]]; then
+    history -s find-alias "$@"
+  fi
 
-tmp_file=$(mktemp -t find-alias.XXXXXXX)
-aliases_tmp_file=$(mktemp -t find-alias.XXXXXXX)
-alias | cat >> "$aliases_tmp_file"
-npx find-alias "$@" "$aliases_tmp_file" --height="$(tput lines)" --page-size="$(tput lines)" --output-file="$tmp_file"
-result="$(<"$tmp_file")"
-rm -f "$tmp_file"
-rm -f "$aliases_tmp_file"
-eval "$result"
+  tmp_file=$(mktemp -t find-alias.XXXXXXX)
+  aliases_tmp_file=$(mktemp -t find-alias.XXXXXXX)
+  alias | cat >>"$aliases_tmp_file"
+  npx find-alias@latest "$@" "$aliases_tmp_file" --height="$(tput lines)" --page-size="$(tput lines)" --output-file="$tmp_file"
+  result="$(<"$tmp_file")"
+  rm -f "$tmp_file"
+  rm -f "$aliases_tmp_file"
+  if [[ -n "$result" ]]; then
+    eval "$result"
 
-if [[ -n "$BASH" ]]; then
-history -s "$result"
-elif [[ -n "$ZSH_VERSION" ]]; then
-print -s "$result"
-fi
+    if [[ -n "$BASH" ]]; then
+      history -s "$result"
+    elif [[ -n "$ZSH_VERSION" ]]; then
+      print -s "$result"
+    fi
+  fi
 }
 ```
 

--- a/find-alias.sh
+++ b/find-alias.sh
@@ -1,20 +1,22 @@
 function <find-alias-caller> {
   if [[ -n "$BASH" ]]; then
-    history -s <find-alias-caller> "$@"
+    history -s <find-alias-caller >"$@"
   fi
 
   tmp_file=$(mktemp -t find-alias.XXXXXXX)
   aliases_tmp_file=$(mktemp -t find-alias.XXXXXXX)
-  alias | cat >> "$aliases_tmp_file"
+  alias | cat >>"$aliases_tmp_file"
   command find-alias "$@" "$aliases_tmp_file" --page-size="$(tput lines)" --output-file="$tmp_file"
   result="$(<"$tmp_file")"
   rm -f "$tmp_file"
   rm -f "$aliases_tmp_file"
-  eval "$result"
+  if [[ -n "$result" ]]; then
+    eval "$result"
 
-  if [[ -n "$BASH" ]]; then
-    history -s "$result"
-  elif [[ -n "$ZSH_VERSION" ]]; then
-    print -s "$result"
+    if [[ -n "$BASH" ]]; then
+      history -s "$result"
+    elif [[ -n "$ZSH_VERSION" ]]; then
+      print -s "$result"
+    fi
   fi
 }


### PR DESCRIPTION
Added verification to ensure to only add not empty commands to bash and zsh history as previously
calling find-alias with --version or --help arguments ended up adding empty entries.